### PR TITLE
Check only subclasses of LinkedCurrencyMoneyField.

### DIFF
--- a/djmoney/models/fields.py
+++ b/djmoney/models/fields.py
@@ -390,7 +390,7 @@ class LinkedCurrencyMoneyField(MoneyField):
         # This nonsense is necessary to prevent django from automatically adding
         # a currency field during migrations.
         for b in self.__class__.__mro__:
-            if b != object:
+            if issubclass(b, LinkedCurrencyMoneyField):
                 setattr(b, "add_currency_field", noop_add_currency_field)
 
         super().contribute_to_class(cls, name)


### PR DESCRIPTION
Fixes so MoneyField can still be used alongside.